### PR TITLE
Support for yamllint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository defines and builds some basic Dockerfiles that are used in the m
 
 | Name                  | Description                                         |
 | --------------------- | --------------------------------------------------- |
-| metal-deployment-base | Can be used when deploying metal-stack with Ansible | 
+| metal-deployment-base | Can be used when deploying metal-stack with Ansible |

--- a/metal-deployment/base/Dockerfile
+++ b/metal-deployment/base/Dockerfile
@@ -25,6 +25,7 @@ RUN set -x \
         libvirt-dev \
         ruby-dev \
         rsync \
+        yamllint \
  && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
  && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable" \
  && apt-get update \


### PR DESCRIPTION
The metal-deployment/base dockerimage is meant to be used to deploy e.g. Ansible code. It would be helpful to have a yaml linter in place to verify the code that is going to be deployed with Ansible is valid yaml.