### PR TITLE
Push to ghcr.io and let PRs of forks pass the pipeline without creating a container image

### DIFF
--- a/.github/workflows/master-deployment.yaml
+++ b/.github/workflows/master-deployment.yaml
@@ -12,14 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.DOCKER_REGISTRY }}
+        username: ${{ secrets.DOCKER_REGISTRY_USER }}
+        password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
     - uses: olegtarasov/get-tag@v1
       id: tagName
+
     - name: Build the Docker images
       run: |
         cd metal-deployment/base
-        docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
         make dockerimage
         make dockerpush
+
     - uses: release-drafter/release-drafter@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,12 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Branch name
-      run: echo running on branch ${GITHUB_HEAD_REF##*/}
+
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.DOCKER_REGISTRY }}
+        username: ${{ secrets.DOCKER_REGISTRY_USER }}
+        password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+      if: github.repository_owner == 'metal-stack'
+
     - name: Build the Docker images
       run: |
-        cd metal-deployment/base
         export GITHUB_TAG_NAME=pr-${GITHUB_HEAD_REF##*/}
-        docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
+        cd metal-deployment/base
         make dockerimage
+
+    - name: Push
+      run: |
+        export GITHUB_TAG_NAME=pr-${GITHUB_HEAD_REF##*/}
+        cd metal-deployment/base
         make dockerpush
+      if: github.repository_owner == 'metal-stack'

--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -10,12 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Branch name
-      run: echo running on branch ${GITHUB_REF##*/}
+
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.DOCKER_REGISTRY }}
+        username: ${{ secrets.DOCKER_REGISTRY_USER }}
+        password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
     - name: Build the Docker images
       run: |
+        export GITHUB_TAG_NAME=pr-${GITHUB_REF##*/}
         cd metal-deployment/base
-        export GITHUB_TAG_NAME=${GITHUB_REF##*/}
-        docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
         make dockerimage
         make dockerpush

--- a/metal-deployment/base/Makefile
+++ b/metal-deployment/base/Makefile
@@ -2,8 +2,8 @@ DOCKER_TAG := $(or ${GITHUB_TAG_NAME}, latest)
 
 .PHONY: dockerimage
 dockerimage:
-	docker build -t metalstack/metal-deployment-base:${DOCKER_TAG} .
+	docker build -t ghcr.io/metal-stack/metal-deployment-base:${DOCKER_TAG} .
 
 .PHONY: dockerpush
 dockerpush:
-	docker push metalstack/metal-deployment-base:${DOCKER_TAG}
+	docker push ghcr.io/metal-stack/metal-deployment-base:${DOCKER_TAG}


### PR DESCRIPTION
Addresses a couple of things:

- Move to ghcr.io
- Allow PRs from forks to pass without creating a container image