### PR TITLE
Still publish deployment-base on Docker Hub.

### DIFF
--- a/.github/workflows/master-deployment.yaml
+++ b/.github/workflows/master-deployment.yaml
@@ -20,6 +20,13 @@ jobs:
         username: ${{ secrets.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
     - uses: olegtarasov/get-tag@v1
       id: tagName
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -23,6 +23,14 @@ jobs:
         password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
       if: steps.fork.outputs.is_fork_pr == 'false'
 
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      if: steps.fork.outputs.is_fork_pr == 'false'
+
     - name: Build the Docker images
       run: |
         export GITHUB_TAG_NAME=pr-${GITHUB_HEAD_REF##*/}

--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -18,6 +18,13 @@ jobs:
         username: ${{ secrets.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
     - name: Build the Docker images
       run: |
         export GITHUB_TAG_NAME=${GITHUB_REF##*/}

--- a/metal-deployment/base/Makefile
+++ b/metal-deployment/base/Makefile
@@ -7,5 +7,11 @@ dockerimage:
 
 .PHONY: dockerpush
 dockerpush:
+	docker tag ghcr.io/metal-stack/metal-deployment-base:${DOCKER_TAG} metalstack/metal-deployment-base:${DOCKER_TAG}
+	docker tag ghcr.io/metal-stack/metal-deployment-base:${DOCKER_TAG}-vagrant metalstack/metal-deployment-base:${DOCKER_TAG}-vagrant
+
 	docker push ghcr.io/metal-stack/metal-deployment-base:${DOCKER_TAG}
 	docker push ghcr.io/metal-stack/metal-deployment-base:${DOCKER_TAG}-vagrant
+
+	docker push metalstack/metal-deployment-base:${DOCKER_TAG}
+	docker push metalstack/metal-deployment-base:${DOCKER_TAG}-vagrant


### PR DESCRIPTION
As this is a pretty important image that we also need to deploy r.metal-stack.io. We should still publish this on Docker Hub.